### PR TITLE
解决 React no-unused-vars 的问题

### DIFF
--- a/template/_eslintrc
+++ b/template/_eslintrc
@@ -5,5 +5,9 @@
     "ecmaFeatures": {
       "jsx": true
     }
+  },
+  "rules": {
+    "react/jsx-uses-react": "error",
+    "react/jsx-uses-vars": "error"
   }
 }

--- a/template/src/app.js
+++ b/template/src/app.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react'; // eslint-disable-line
+import React, { Component } from 'react';
 import { render } from 'react-dom';
 
-class Example extends Component { // eslint-disable-line
+class Example extends Component {
   render() {
     return <h1>Hello World!</h1>;
   }


### PR DESCRIPTION
解决 `import` `React` 和 `自定义组件` 时 `eslint` 报 `xxx is defined but never used` 的问题
